### PR TITLE
Squash type-related warnings in distributed-mst.lisp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,31 +31,17 @@ test:
 		--eval "(asdf:test-system :aether)"
 
 ###
-### clean targets, borrowed from QVM
+### clean targets (borrowed from QVM)
 ###
 
-# Clean the executables
 clean:
-	rm -f qvm qvm-ng build-output.log system-index.txt
-
-# Clean the Lisp cache, reindex local projects.
-clean-cache:
-	@echo "Deleting $(LISP_CACHE)"
-	$(QUICKLISP) \
-		--eval "(ql:register-local-projects)"
-	rm -rf "$(LISP_CACHE)"
-
-clean-qvm-cache:
-	@echo "Deleting $(QVM_LISP_CACHE)"
-	$(QUICKLISP) \
-		--eval "(ql:register-local-projects)"
-	rm -rf $(QVM_LISP_CACHE)
+	rm -f system-index.txt
 
 clean-quicklisp:
 	@echo "Cleaning up old projects in Quicklisp"
 	$(QUICKLISP) \
 		--eval '(ql-dist:clean (ql-dist:dist "quicklisp"))'
 
-cleanall: clean clean-cache clean-quicklisp
+cleanall: clean clean-quicklisp
 	@echo "All cleaned and reindexed."
 

--- a/tests/examples/distributed-mst.lisp
+++ b/tests/examples/distributed-mst.lisp
@@ -72,7 +72,7 @@
    ;; denoted by FN in the paper pseudocode
    (fragment-weight
     :initform nil
-    :type (or nil integer)
+    :type (or null integer)
     :accessor fragment-node-fragment-weight)
    ;; denoted by LN in the paper pseudocode
    (fragment-level
@@ -82,7 +82,6 @@
     :documentation "An integer between 0 and log N (where N is the number of nodes).")
    ;; contains edge identifiers, weights, and states (SE)
    (adjacent-edges
-    :initform nil
     :initarg :adjacent-edges
     :type hash-table
     :accessor fragment-node-adjacent-edges


### PR DESCRIPTION
This should hopefully address #26

Snuck in some `Makefile` cleanup.