### PR TITLE
Use integers to identify messages, channels, couriers

### DIFF
--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -148,3 +148,21 @@ WARNING: This routine is based on MAPHASH, which has undefined behavior if the s
                     (parse-option item))
                    (t
                     (error "Unknown lambda list chunk: ~a~%" item))))))
+
+;; see rigetti/quilc/src/utilities.lisp
+(defmacro define-global-counter (counter-name incf-name)
+  `(progn
+     (declaim (type fixnum ,counter-name))
+     (global-vars:define-global-var ,counter-name 0)
+     (declaim (inline ,incf-name))
+     (defun ,incf-name ()
+       #+sbcl
+       (sb-ext:atomic-incf ,counter-name)
+       #+lispworks
+       (system:atomic-incf ,counter-name)
+       #+ecl
+       (mp:atomic-incf ,counter-name)
+       #+ccl
+       (ccl::atomic-incf ,counter-name)
+       #-(or ccl ecl sbcl lispworks)
+       (incf ,counter-name))))


### PR DESCRIPTION
We made the somewhat unusual design decision to use non-interned symbols to uniquely identify large collections of transient objects. In applications, we tend to generate millions of these symbols, most of which do not linger.

This PR replaces these symbols with mere integers. These are somewhat less unique — it's possible to re-use integer in a sense that's impossible with non-interned symbols — but our use of counters keeps us out of trouble. I don't yet know if this is worth merging, but here it is.