### PR TITLE
emit debug messages in emissaries

### DIFF
--- a/src/process/emissary.lisp
+++ b/src/process/emissary.lisp
@@ -27,10 +27,9 @@
            ((,process ,process-type) (,message ,message-type) ,now)
          (let ((,servicer (spawn-process 'process-message-emissary)))
            (future ,servicer ,now)
-           (setf (process-command-stack ,servicer)
-                 (list (list ',command ,process ,message))
-                 (process-clock-rate ,servicer)
-                 (process-clock-rate ,process))
+           (setf (process-command-stack ,servicer) (list (list ',command ,process ,message))
+                 (process-clock-rate ,servicer)    (process-clock-rate ,process)
+                 (process-debug? ,servicer)        (process-debug? ,process))
            (values)))
        
        (define-process-upkeep ((,subprocess process-message-emissary) ,now)


### PR DESCRIPTION
We forgot to propagate the `debug?` flag to the subprocess spawned by `define-message-subordinate`, resulting in missing log entries. This PR fixes that.