### PR TITLE
Rename "future" and friends to "schedule" and friends

### DIFF
--- a/src/cast.lisp
+++ b/src/cast.lisp
@@ -31,7 +31,7 @@
 1. `PUSH-BROADCAST-FRAME', which creates a `BROADCAST-FRAME' and pushes it onto the data stack. If no `MESSAGE' is provided to the function, it defaults to the `MESSAGE' currently being handled. If a user calls `PUSH-BROADCAST-FRAME' twice in the same handler, an error will be raised.
 2. `RETURN-FROM-CAST', which allows the user to terminate the broadcast operation early by sending up an acknowledgement (optionally specifying its contents) to the original sender of `MESSAGE'.
 
-WARNING: `RETURN-FROM-CAST' calls `PUSH-BROADCAST-FRAME' as part of the aborting process. If a frame has already been pushed onto the data stack, we instead alter that frame rather than pushing an additional one (which could have strange consequences). Additionally, it is important to note that `RETURN-FROM-CAST' uses `FINISH-WITH-FUTURES' in order to return from the handler early."
+WARNING: `RETURN-FROM-CAST' calls `PUSH-BROADCAST-FRAME' as part of the aborting process. If a frame has already been pushed onto the data stack, we instead alter that frame rather than pushing an additional one (which could have strange consequences). Additionally, it is important to note that `RETURN-FROM-CAST' uses `FINISH-WITH-SCHEDULING' in order to return from the handler early."
   (a:with-gensyms (broadcast-frame reply-channel)
     `(define-message-handler ,handler-name
          ((,process ,process-type) (,message ,message-type) ,now)
@@ -65,7 +65,7 @@ WARNING: `RETURN-FROM-CAST' calls `PUSH-BROADCAST-FRAME' as part of the aborting
                     (when ,reply-channel
                       (send-message ,reply-channel (make-message-rpc-done
                                                     :result value)))
-                    (finish-with-futures)))
+                    (finish-with-scheduling)))
              (declare (ignorable #'return-from-cast))
              ;; Push `BROADCAST' before executing the body, in case the body
              ;; pushes an additional script onto the command stack that is
@@ -136,7 +136,7 @@ Where `REPLIES' is assumed to be a `LIST'. Additionally, when `HANDLE-RTS?' is t
 1. `PUSH-CONVERGECAST-FRAME', which creates a `CONVERGECAST-FRAME' and pushes it onto the data stack. If no `MESSAGE' is provided to the function, it defaults to the `MESSAGE' currently being handled. If a user calls `PUSH-BROADCAST-FRAME' twice in the same handler, an error will be raised.
 2. `RETURN-FROM-CAST', which allows the user to terminate the convergecast operation early by sending up an acknowledgement (optionally specifying its contents) to the original sender of `MESSAGE'. It is recommended that a value is provided when returning from a convergecast, as it will be passed to a function (the function provided to the `CONVERGECAST-FRAME') when received by the original sender.
 
-WARNING: `RETURN-FROM-CAST' calls `PUSH-CONVERGECAST-FRAME' as part of the aborting process. If a frame has already been pushed onto the data stack, we instead alter that frame rather than pushing an additional one (which could have strange consequences). Additionally, it is important to note that `RETURN-FROM-CAST' uses `FINISH-WITH-FUTURES' in order to return from the handler early."
+WARNING: `RETURN-FROM-CAST' calls `PUSH-CONVERGECAST-FRAME' as part of the aborting process. If a frame has already been pushed onto the data stack, we instead alter that frame rather than pushing an additional one (which could have strange consequences). Additionally, it is important to note that `RETURN-FROM-CAST' uses `FINISH-WITH-SCHEDULING' in order to return from the handler early."
   (a:with-gensyms (convergecast-frame reply-channel)
     `(define-message-handler ,handler-name
          ((,process ,process-type) (,message ,message-type) ,now)
@@ -173,7 +173,7 @@ WARNING: `RETURN-FROM-CAST' calls `PUSH-CONVERGECAST-FRAME' as part of the abort
                     (when ,reply-channel
                       (send-message ,reply-channel (make-message-rpc-done
                                                     :result value)))
-                    (finish-with-futures)))
+                    (finish-with-scheduling)))
              (declare (ignorable #'return-from-cast))
              (process-continuation ,process `(CONVERGECAST))
              ,@body))))))

--- a/src/event.lisp
+++ b/src/event.lisp
@@ -115,28 +115,28 @@ HORIZON: The timestamp before which all events have been simulated.  Ensures tha
 ;;; DSL for building event producers associated to object types
 ;;;
 
-(defmacro with-futures (&body body)
-  "Stores an implicit set of EVENT objects to return when exiting the WITH-FUTURE block.
+(defmacro with-scheduling (&body body)
+  "Stores an implicit set of EVENT objects to return when exiting the WITH-SCHEDULING block.
 
-Provides some helper functions: FUTURE, FUTURE*, and FINISH-WITH-FUTURES."
-  (alexandria:with-gensyms (block-name futures-collection last-value)
-    `(let (,futures-collection ,last-value)
+Provides some helper functions: SCHEDULE, SCHEDULE*, and FINISH-WITH-SCHEDULING."
+  (alexandria:with-gensyms (block-name event-collection last-value)
+    `(let (,event-collection ,last-value)
        (block ,block-name
-         (labels ((future (fn-or-obj time)
+         (labels ((schedule (fn-or-obj time)
                     (push (make-event :callback fn-or-obj
                                       :time time)
-                          ,futures-collection)
+                          ,event-collection)
                     (values))
-                  (future* (events)
-                    (setf ,futures-collection
-                          (append events ,futures-collection))
+                  (schedule* (events)
+                    (setf ,event-collection
+                          (append events ,event-collection))
                     (values))
-                  (finish-with-futures (&optional (events nil eventsp))
+                  (finish-with-scheduling (&optional (events nil eventsp))
                     (return-from ,block-name
-                      (if eventsp events ,futures-collection))))
-           (declare (ignorable #'future #'future* #'finish-with-futures))
+                      (if eventsp events ,event-collection))))
+           (declare (ignorable #'schedule #'schedule* #'finish-with-scheduling))
            (setf ,last-value (progn ,@body))
-           (values ,futures-collection ,last-value))))))
+           (values ,event-collection ,last-value))))))
 
 (defmacro define-object-handler (((object-variable object-type) time-variable) &body body)
   "Defines a default event handler for OBJECT-TYPE."
@@ -144,23 +144,23 @@ Provides some helper functions: FUTURE, FUTURE*, and FINISH-WITH-FUTURES."
     `(defmethod handle-object ((,object-variable ,object-type) ,time-variable)
        ,@(when docstring (list docstring))
        ,@(when decls decls)
-       (with-futures
+       (with-scheduling
          ,@forms))))
 
-(defun future (fn-or-obj time)
+(defun schedule (fn-or-obj time)
   "Installs a future EVENT object, which invokes FN-OR-OBJ at the specified TIME."
   (declare (ignore fn-or-obj time))
-  (error "FUTURE is not defined outside of WITH-FUTURES."))
+  (error "SCHEDULE is not defined outside of WITH-SCHEDULING."))
 
-(defun future* (event-list)
+(defun schedule* (event-list)
   "Installs a list of future EVENT objects."
   (declare (ignore event-list))
-  (error "FUTURE* is not defined outside of WITH-FUTURES."))
+  (error "SCHEDULE* is not defined outside of WITH-SCHEDULING."))
 
-(defun finish-with-futures (&optional event-list)
-  "Breaks out of WITH-FUTURE. If EVENTS is supplied, returns EVENTS in place of the implicit event list."
+(defun finish-with-scheduling (&optional event-list)
+  "Breaks out of WITH-SCHEDULING. If EVENTS is supplied, returns EVENTS in place of the implicit event list."
   (declare (ignore event-list))
-  (error "FINISH-WITH-FUTURES is not defined outside of WITH-FUTURES."))
+  (error "FINISH-WITH-SCHEDULING is not defined outside of WITH-SCHEDULING."))
 
 
 

--- a/src/event.lisp
+++ b/src/event.lisp
@@ -165,7 +165,7 @@ Provides some helper functions: SCHEDULE, SCHEDULE*, and FINISH-WITH-SCHEDULING.
 
 ;;; deprecated "future" naming scheme
 
-(defmacro with-future (&body body)
+(defmacro with-futures (&body body)
   "WARNING: This macro is deprecated in favor of `WITH-SCHEDULING` and will be removed in a future release.
 
 Stores an implicit set of EVENT objects to return when exiting the WITH-FUTURES block.

--- a/src/event.lisp
+++ b/src/event.lisp
@@ -13,7 +13,7 @@
   (callback nil :read-only t)
   (time       0 :read-only t :type (rational 0)))
 
-(defgeneric handle-object (object time)
+(defgeneric handle-object (object now)
   (:documentation "Describes the generic behavior of OBJECTs of a particular type, as occuring at a particular TIME."))
 
 (defstruct (simulation (:constructor %make-simulation))

--- a/src/event.lisp
+++ b/src/event.lisp
@@ -163,6 +163,50 @@ Provides some helper functions: SCHEDULE, SCHEDULE*, and FINISH-WITH-SCHEDULING.
   (error "FINISH-WITH-SCHEDULING is not defined outside of WITH-SCHEDULING."))
 
 
+;;; deprecated "future" naming scheme
+
+(defmacro with-future (&body body)
+  "WARNING: This macro is deprecated in favor of `WITH-SCHEDULING` and will be removed in a future release.
+
+Stores an implicit set of EVENT objects to return when exiting the WITH-FUTURES block.
+
+Provides some helper functions: FUTURE, FUTURE*, and FINISH-WITH-FUTURES."
+  (warn "WITH-FUTURE is deprecated in favor of WITH-SCHEDULING and will be removed in a future release.")
+  `(with-scheduling
+    (flet ((future (fn-or-obj time)
+             (schedule fn-or-obj time))
+           (future* (events)
+             (schedule* events))
+           (finish-with-futures (&optional (events nil eventsp))
+             (cond
+              (eventsp
+                (finish-with-scheduling events))
+              (t
+                (finish-with-scheduling)))))
+      (declare (ignorable #'future #'future* #'finish-with-futures))
+      ,@body)))
+
+(defun future (fn-or-obj time)
+  "WARNING: This function is deprecated in favor of `SCHEDULE` and will be removed in a future release.
+
+Installs a future EVENT object, which invokes FN-OR-OBJ at the specified TIME."
+  (declare (ignore fn-or-obj time))
+  (error "FUTURE is not defined outside of WITH-FUTURES."))
+
+(defun future* (event-list)
+  "WARNING: This function is deprecated in favor of `SCHEDULE*` and will be removed in a future release.
+
+Installs a list of future EVENT objects."
+  (declare (ignore event-list))
+  (error "FUTURE* is not defined outside of WITH-FUTURES."))
+
+(defun finish-with-futures (&optional event-list)
+  "WARNING: This function is deprecated in favor of `FINISH-WITH-SCHEDULING` and will be removed in a future release.
+
+Breaks out of WITH-FUTURES. If EVENTS is supplied, returns EVENTS in place of the implicit event list."
+  (declare (ignore event-list))
+  (error "FINISH-WITH-FUTURES is not defined outside of WITH-FUTURES."))
+
 
 ;; Here lies an implementation of SIMULATION on top of a bare CL-HEAP.  It's
 ;; very slow and memory-expensive in our use case!

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -236,27 +236,27 @@ NOTES:
 ;;; event producers for message passing infrastructure
 ;;;
 
-(define-object-handler ((courier courier) time)
+(define-object-handler ((courier courier) now)
   "Processes messages in the COURIER's I/O queue: messages bound for other COURIERs get forwarded, and messages bound for this COURIER get sorted into local mailboxes."
   (when (q-empty (courier-queue courier))
-    (schedule courier (+ time (/ (courier-processing-clock-rate courier))))
+    (schedule courier (+ now (/ (courier-processing-clock-rate courier))))
     (finish-with-scheduling))
   (let ((message (q-deq (courier-queue courier)))
         (*local-courier* courier))
     (cond
       ;; are we this message's destination?
       ((stash-local-message message)
-       (schedule courier time))
+       (schedule courier now))
       ;; otherwise, route it
       (t
        (multiple-value-bind (intermediate-destination time-to-deliver)
            (courier-courier->route courier (first message))
          (setf time-to-deliver (or time-to-deliver
                                    (courier-default-routing-time-step courier)))
-         (schedule courier (+ time (/ (courier-processing-clock-rate courier))))
+         (schedule courier (+ now (/ (courier-processing-clock-rate courier))))
          (schedule (ignorant-lambda
                      (deliver-message intermediate-destination message))
-                   (+ time time-to-deliver)))))))
+                   (+ now time-to-deliver)))))))
 
 ;;;
 ;;; standard message types

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -62,10 +62,10 @@
    #:make-simulation                    ; FUNCTION
    #:simulation-add-event               ; FUNCTION
    #:simulation-run                     ; FUNCTION
-   #:with-futures                       ; MACRO
-   #:future                             ; FUNCTION
-   #:future*                            ; FUNCTION
-   #:finish-with-futures                ; MACRO
+   #:with-scheduling                    ; MACRO
+   #:schedule                           ; FUNCTION
+   #:schedule*                          ; FUNCTION
+   #:finish-with-scheduling             ; MACRO
    
    #:canary-until                       ; FUNCTION
    #:canary-timeout                     ; FUNCTION

--- a/src/process/dpu-helpers.lisp
+++ b/src/process/dpu-helpers.lisp
@@ -62,13 +62,13 @@
   (a:with-gensyms (repeater finalizer)
     `(flet ((,repeater (,now)
               (declare (ignorable ,now))
-              (with-futures ,@repeater-body))
+              (with-scheduling ,@repeater-body))
             (,finalizer (,now)
               (declare (ignorable ,now))
-              (with-futures ,@finalizer-body)))
+              (with-scheduling ,@finalizer-body)))
        (push (list 'REPEAT-UNTIL #',repeater #',finalizer)
              (process-command-stack ,process-name))
-       (finish-with-futures))))
+       (finish-with-scheduling))))
 
 ;; TODO: "SYNC"-RECEIVE is a somewhat misleading name.
 ;;       it's more like a busywaiting callback?
@@ -78,25 +78,25 @@
 IMPORTANT WARNING: `SYNC-RECEIVE' returns after it finishes executing its body.  Any code following a `SYNC-RECEIVE' **will not** be executed.
 
 NOTE: `MESSAGE-RTS' replies must be explicitly handled.  Otherwise, the default behavior is to throw an error, which can be seen in the definition of `RECEIVE-MESSAGE'."
-  (a:with-gensyms (sr-futures sr-done? record)
+  (a:with-gensyms (sr-events sr-done? record)
     `(%install-repeat-until
          ((log-entry :entry-type 'command
                      :time ,now
                      :command 'sync-receive
                      :next-command (caar (process-command-stack ,process-name))
                      :sync-channel ,sync-channel)
-           (multiple-value-bind (,sr-futures ,sr-done?)
+           (multiple-value-bind (,sr-events ,sr-done?)
                (receive-message (,sync-channel ,sync-message-place)
                  ,@(loop :for (clause-head . clause-body) :in sync-clauses
                          :collect `(,clause-head
-                                    (with-futures
+                                    (with-scheduling
                                       (a:when-let ((,record (process-debug? ,process-name)))
                                         (setf ,record (list* ':delta (- ,now (getf ,record ':time))
                                                              ,record))
                                         (remf ,record ':time)
                                         (apply #'tracer-store ,record))
                                       ,@clause-body))))
-             (future* ,sr-futures)
+             (schedule* ,sr-events)
              ,sr-done?))
          (
           ;; no finalization after finishing the receive
@@ -166,11 +166,11 @@ Typical use looks like:
 ;;;
 
 (define-process-upkeep ((process T) time) (REPEAT-UNTIL callback finalize)
-  "Repeatedly calls CALLBACK: (TIME) --> (VALUES FUTURES DONE?) until DONE? is non-NIL.  Then, calls FINALIZE: (TIME) --> (FUTURES) once."
-  (multiple-value-bind (futures done?) (funcall callback time)
-    (future* futures)
+  "Repeatedly calls CALLBACK: (TIME) --> (VALUES EVENTS DONE?) until DONE? is non-NIL.  Then, calls FINALIZE: (TIME) --> (EVENTS) once."
+  (multiple-value-bind (events done?) (funcall callback time)
+    (schedule* events)
     (cond
       ((and done? finalize)
-       (future* (funcall finalize time)))
+       (schedule* (funcall finalize time)))
       (t
        (push `(REPEAT-UNTIL ,callback ,finalize) (process-command-stack process))))))

--- a/src/process/dpu-helpers.lisp
+++ b/src/process/dpu-helpers.lisp
@@ -165,12 +165,12 @@ Typical use looks like:
 ;;; commands
 ;;;
 
-(define-process-upkeep ((process T) time) (REPEAT-UNTIL callback finalize)
+(define-process-upkeep ((process T) now) (REPEAT-UNTIL callback finalize)
   "Repeatedly calls CALLBACK: (TIME) --> (VALUES EVENTS DONE?) until DONE? is non-NIL.  Then, calls FINALIZE: (TIME) --> (EVENTS) once."
-  (multiple-value-bind (events done?) (funcall callback time)
+  (multiple-value-bind (events done?) (funcall callback now)
     (schedule* events)
     (cond
       ((and done? finalize)
-       (schedule* (funcall finalize time)))
+       (schedule* (funcall finalize now)))
       (t
        (push `(REPEAT-UNTIL ,callback ,finalize) (process-command-stack process))))))

--- a/src/process/emissary.lisp
+++ b/src/process/emissary.lisp
@@ -26,7 +26,7 @@
        (define-message-handler ,handler-name
            ((,process ,process-type) (,message ,message-type) ,now)
          (let ((,servicer (spawn-process 'process-message-emissary)))
-           (future ,servicer ,now)
+           (schedule ,servicer ,now)
            (setf (process-command-stack ,servicer) (list (list ',command ,process ,message))
                  (process-clock-rate ,servicer)    (process-clock-rate ,process)
                  (process-debug? ,servicer)        (process-debug? ,process))

--- a/src/rpc.lisp
+++ b/src/rpc.lisp
@@ -5,7 +5,7 @@
 
 (in-package #:aether)
 
-;; TODO: this traps RETURN-FROM, but not FINISH-WITH-FUTURES.
+;; TODO: this traps RETURN-FROM, but not FINISH-WITH-SCHEDULING.
 (defmacro define-rpc-handler (handler-name
                               ((process process-type) (message message-type) now)
                               &body body)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -79,9 +79,9 @@ WARNING: This routine is based on MAPHASH, which has undefined behavior if the s
 
 (defmacro ignorant-lambda (&body body)
   "Defines an anonymous function that discards all of its arguments."
-  (a:with-gensyms (time)
-    `(lambda (,time)
-       (declare (ignore ,time))
+  (a:with-gensyms (rest)
+    `(lambda (&rest ,rest)
+       (declare (ignore ,rest))
        ,@body)))
 
 (defun peek (list)

--- a/tests/cast.lisp
+++ b/tests/cast.lisp
@@ -47,13 +47,13 @@
 ;;;
 
 (define-broadcast-handler handle-broadcast-test
-    ((process process-tree-cast-test) (message broadcast-test) time)
+    ((process process-tree-cast-test) (message broadcast-test) now)
   "Pushes the `PROCESS's ID to a global list."
   (push (process-tree-id process) *broadcast-events*)
   (push-broadcast-frame :targets (process-tree-children process)))
 
 (define-broadcast-handler handle-broadcast-test-abort
-    ((process process-tree-cast-test) (message broadcast-test-abort) time)
+    ((process process-tree-cast-test) (message broadcast-test-abort) now)
   "Pushes the `PROCESS's ID to a global list, and potentially aborts the broadcast if the `PROCESS's ID is equal to `ABORT-ID'."
   (with-slots (abort-id) message
     (push (process-tree-id process) *broadcast-events*)
@@ -62,28 +62,28 @@
       (return-from-cast))))
 
 (define-broadcast-handler handle-broadcast-test-script
-    ((process process-tree-cast-test) (message broadcast-test-script) time)
+    ((process process-tree-cast-test) (message broadcast-test-script) now)
   "Pushes the `:PUSH-TIMES' command onto the stack."
   (with-slots (scalar) message
     (process-continuation process `(PUSH-TIMES ,scalar))
     (push-broadcast-frame :targets (process-tree-children process))))
 
 (define-broadcast-handler handle-broadcast-test-rts
-    ((process process-tree-cast-test) (message broadcast-test-rts) time)
+    ((process process-tree-cast-test) (message broadcast-test-rts) now)
   "Pushes the `PROCESS's ID to a global list."
   (push (process-tree-id process) *broadcast-events*)
   (push-broadcast-frame :targets (process-tree-children process)
                         :handle-rts? t))
 
 (define-convergecast-handler handle-convergecast-test
-    ((process process-tree-cast-test) (message convergecast-test) time)
+    ((process process-tree-cast-test) (message convergecast-test) now)
   "Puts the `PROCESS's ID as `INPUT' to the convergcast frame."
   (push-convergecast-frame :targets (process-tree-children process)
                            :func #'aether::reduce+
                            :input (process-tree-id process)))
 
 (define-convergecast-handler handle-convergecast-test-abort
-    ((process process-tree-cast-test) (message convergecast-test-abort) time)
+    ((process process-tree-cast-test) (message convergecast-test-abort) now)
   "Puts the `PROCESS's ID as `INPUT' to the convergcast frame, unless it is equal to `ABORT-ID', which triggers a `RETURN-FROM-CAST' and thus an abort of the convergecast operation."
   (with-slots (abort-id) message
     (push-convergecast-frame :targets (process-tree-children process)
@@ -93,7 +93,7 @@
       (return-from-cast 0))))
 
 (define-convergecast-handler handle-convergecast-test-script
-    ((process process-tree-cast-test) (message convergecast-test-script) time)
+    ((process process-tree-cast-test) (message convergecast-test-script) now)
   "Pushes the `:SET-TIMES' command onto the stack."
   (with-slots (scalar) message
     (process-continuation process `(SET-TIMES ,scalar))
@@ -102,7 +102,7 @@
                              :input (process-tree-id process))))
 
 (define-convergecast-handler handle-convergecast-test-rts
-    ((process process-tree-cast-test) (message convergecast-test-rts) time)
+    ((process process-tree-cast-test) (message convergecast-test-rts) now)
   "Puts the `PROCESS's ID as `INPUT' to the convergcast frame. In order to handle RTSes gracefully, our `FUNC' must also handle NILs."
   (labels ((null+ (input replies)
              (loop :for value :in (list* input replies)

--- a/tests/event.lisp
+++ b/tests/event.lisp
@@ -22,7 +22,7 @@
              :time now
              :entry-type 'a
              :slot (a-slot a))
-  (future a (1+ now)))
+  (schedule a (1+ now)))
 
 (define-object-handler ((b b) now)
   (log-entry :source b
@@ -30,15 +30,15 @@
              :time now
              :entry-type 'b)
   (when (< now (b-cutoff b))
-    (future b (+ 1 now))
-    (future b (+ 2 now))))
+    (schedule b (+ 1 now))
+    (schedule b (+ 2 now))))
 
 (define-object-handler ((c c) now)
   (log-entry :source c
              :source-type (type-of c)
              :time now
              :entry-type 'c)
-  (future* (call-next-method)))
+  (schedule* (call-next-method)))
 
 (deftest test-event-loop ()
   (with-transient-logger ()

--- a/tests/examples/coloring.lisp
+++ b/tests/examples/coloring.lisp
@@ -58,7 +58,7 @@
   "Coordinates with the node's `NEIGHBORS' so as to have a distinct `COLOR' value."
   (process-continuation process `(START))
   (when (zerop (process-coloring-workloads process))
-    (finish-with-futures))
+    (finish-with-scheduling))
   (setf (process-coloring-color process) (random 3))
   (with-replies (replies)
                 (send-message-batch #'make-message-color-query

--- a/tests/examples/data-frame.lisp
+++ b/tests/examples/data-frame.lisp
@@ -151,7 +151,7 @@ This assumes that the return-value has already been set up, contributes the fact
     (flet ((delay-send (message time)
              (make-event :time time
                          :callback (ignorant-lambda
-                                     (with-futures
+                                     (with-scheduling
                                        (send-message (process-public-address server)
                                                      message)))))
            (test-expect (x)

--- a/tests/examples/distributed-mst.lisp
+++ b/tests/examples/distributed-mst.lisp
@@ -145,7 +145,7 @@
 
 ;; section 3 of the paper pseudocode: response to Connect
 (define-message-handler handle-msg-connect
-    ((node fragment-node) (message msg-connect) time)
+    ((node fragment-node) (message msg-connect) now)
   "If we get a Connect message from a lower-level fragment, then mark that edge as a Branch and send an Initate message to absorb that fragment. Else, if the sender is at the end of a Basic edge, then wait (via a self-send). Otherwise, we've received a Connect message from a fragment of equal level, and thus we would like to merge with it. We do so by sending it an Initiate message with a higher level, and with the edge weight.
 
 NOTE: the following line is implemented using a guard in `DEFINE-MESSAGE-DISPATCH'
@@ -202,7 +202,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 4 of the paper pseudocode: response to Initiate
 (define-message-handler handle-msg-initiate
-    ((node fragment-node) (message msg-initiate) time)
+    ((node fragment-node) (message msg-initiate) now)
   "An Initiate is a broadcast that is triggered in response to handling a Connect. In step 1, we update our internal state. In step 2, we continue the broadcast if we have any branches. Finally, in step 3, we push a `TEST' onto the stack if we are in the Find state."
   (let ((address (process-public-address node)))
     (with-slots (adjacent-edges find-count) node
@@ -243,7 +243,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 6 of the paper pseudocode: response to Test
 (define-message-handler handle-msg-test
-    ((node fragment-node) (message msg-test) time)
+    ((node fragment-node) (message msg-test) now)
   "Response to a Test message. If our level is <= to that of the message, then we wait (by self-sending the message). Else, if we are part of a different fragment, then we send an Accept.
 
 Otherwise, we should reject the edge that this message came from. We only mark the edge as Rejected if it is Basic -- if it's not Basic, then this is essentially a stale Test. However, even in the case that it is stale, we likely want to send back a Reject message to allow the sender to resume progress. Finally, we push a `TEST' onto the stack.
@@ -296,7 +296,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 7 of the paper pseudocode: response to Accept
 (define-message-handler handle-msg-accept
-    ((node fragment-node) (message msg-accept) time)
+    ((node fragment-node) (message msg-accept) now)
   "If accepted edge weight is less than `BEST-WEIGHT', update `BEST-WEIGHT' and `BEST-EDGE'. Either way, push `REPORT' onto the stack."
   ;; extract best-edge, best-wt, test-edge from node
   (with-slots (adjacent-edges best-edge best-weight test-edge) node
@@ -315,7 +315,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 8 of the paper pseudocode: response to Reject
 (define-message-handler handle-msg-reject
-    ((node fragment-node) (message msg-reject) time)
+    ((node fragment-node) (message msg-reject) now)
   "Mark edge as Rejected (if it is Basic), and push `TEST' onto the stack."
   (with-slots (adjacent-edges) node
     ;; extract j from message
@@ -329,7 +329,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 10 of the paper pseudocode: response to Report
 (define-message-handler handle-msg-report
-    ((node fragment-node) (message msg-report) time)
+    ((node fragment-node) (message msg-report) now)
   "If we get a Report from someone that's not our `IN-BRANCH', then we decrement `FIND-COUNT', potentially update our best edge & weight, and then proceed to `REPORT'. Else, if we're in the Find state, wait (via a self-send). Else, if the Report weight is lower than `BEST-WEIGHT', we should `CHANGE-ROOT'. Finally, if the Report weight and `BEST-WEIGHT' are both inifinity, then we're part of the core and have discovered the full MST, so it's time to stop."
   ;; extract best-edge, best-wt, find-count, in-branch, SN from node
   (with-slots (best-edge best-weight find-count in-branch) node
@@ -375,7 +375,7 @@ if SN = sleeping then execute procedure wakeup"
 
 ;; section 12 of the paper pseudocode: response to Change-root
 (define-message-handler handle-msg-change-root
-    ((node fragment-node) (message msg-change-root) time)
+    ((node fragment-node) (message msg-change-root) now)
   "Push a `CHANGE-ROOT' command onto the stack."
   (process-continuation node `(CHANGE-ROOT)))
 

--- a/tests/process.lisp
+++ b/tests/process.lisp
@@ -35,7 +35,7 @@
 ;; the message handlers
 
 (define-message-handler handle-msg-ping
-    ((box chatterbox) (message msg-ping) time)
+    ((box chatterbox) (message msg-ping) now)
   (with-slots (reply-channel) message
     (send-message reply-channel (make-msg-pong :vote (vote box)))))
 
@@ -46,13 +46,13 @@
 
 ;;; the process commands
 
-(define-process-upkeep ((box chatterbox) time)
+(define-process-upkeep ((box chatterbox) now)
     (START)
   (process-continuation box
                         `(PING ,*chatterbox-addresses*)
                         `(WAIT)))
 
-(define-process-upkeep ((box chatterbox) time)
+(define-process-upkeep ((box chatterbox) now)
     (PING addresses)
   (unless (endp addresses)
     (let* ((address (pop addresses))
@@ -65,12 +65,12 @@
          (unregister listen-channel)
          (process-continuation box `(TALLY ,(msg-pong-vote pong-message))))))))
 
-(define-process-upkeep ((box chatterbox) time)
+(define-process-upkeep ((box chatterbox) now)
     (TALLY vote)
   (incf (pongs box))
   (incf (tally box) vote))
 
-(define-process-upkeep ((box chatterbox) time)
+(define-process-upkeep ((box chatterbox) now)
     (WAIT)
   (process-continuation box `(WAIT)))
 


### PR DESCRIPTION
We realized in conversation with an expert that we were misusing the technical word "future". This PR renames what we were calling "future" to "schedule", which is better aligned with existing technical meanings.

This PR also retains the existing name "future", with a deprecation warning. If / once this PR is merged, we should open an issue to remember to remove it outright in a future release.