### PR TITLE
drop `:source-type` from log entries

### DIFF
--- a/src/debug/logger.lisp
+++ b/src/debug/logger.lisp
@@ -20,9 +20,9 @@
 ;;     automatic 'conversion' routines which do things like, e.g., discard
 ;;     pointers to objects and retain only their public addresses.
 
-(defun log-entry (&rest initargs &key (logger *logger*) source source-type time entry-type &allow-other-keys)
+(defun log-entry (&rest initargs &key (logger *logger*) source time entry-type &allow-other-keys)
   "Injects a log entry."
-  (declare (ignore source source-type entry-type time))
+  (declare (ignore source entry-type time))
   (when logger
     (let ((keys (copy-seq initargs)))
       (remf keys ':logger)
@@ -43,29 +43,26 @@
 
 ;;; pretty-printing mechanisms
 
-(defgeneric print-log-entry (entry source-type entry-type &optional stream)
+(defgeneric print-log-entry (entry source entry-type &optional stream)
   (:documentation "Pretty-prints a log entry to STREAM.")
-  (:method (entry source-type entry-type &optional (stream *standard-output*))
+  (:method (entry source entry-type &optional (stream *standard-output*))
     (let ((entry (copy-seq entry))
           (time (getf entry ':time))
-          (source-type (getf entry ':source-type))
           (source (getf entry ':source))
           (entry-type (getf entry ':entry-type)))
       (remf entry ':time)
-      (remf entry ':source-type)
       (remf entry ':source)
       (remf entry ':entry-type)
-      (format stream "~5f: ~a @ ~a logged ~a:~%    ~a~%"
-              time source-type source entry-type
+      (format stream "~5f: ~a logged ~a:~%    ~a~%"
+              time source entry-type
               entry))))
 
 (defmethod print-log-entry (entry
-                            source-type
+                            source
                             (entry-type (eql 'SEND-MESSAGE))
                             &optional (stream *standard-output*))
-  (format stream "~5f: ~a @ ~a sending ~a to ~a:~%    ~a~%"
+  (format stream "~5f: ~a sending ~a to ~a:~%    ~a~%"
           (getf entry ':time)
-          (getf entry ':source-type)
           (getf entry ':source)
           (type-of (getf entry ':payload))
           (getf entry ':destination)
@@ -74,7 +71,7 @@
 (defun print-log (entries &optional (stream *standard-output*))
   (dolist (entry entries)
     (print-log-entry entry
-                     (getf entry ':source-type)
+                     (getf entry ':source)
                      (getf entry ':entry-type)
                      stream)))
 

--- a/src/process/process.lisp
+++ b/src/process/process.lisp
@@ -128,8 +128,7 @@ IMPORTANT NOTE: Use #'SPAWN-PROCESS to generate a new PROCESS object."))
                     (apply #'log-entry
                            (append initargs
                                    (list :time (now)
-                                         :source-type ',process-type
-                                         :source (process-public-address ,process)))))))
+                                         :source ,process))))))
            (flet ((send-message (destination payload)
                     (log-entry :entry-type 'send-message
                                :destination destination
@@ -181,10 +180,9 @@ WARNING: These actions are to be thought of as \"interrupts\". Accordingly, you 
                                                       ,node))
                       (,message-type
                        (when (process-debug? ,node)
-                         (log-entry :source-type ',node-type
-                                    :time (now)
+                         (log-entry :time (now)
                                     :entry-type 'handler-invoked
-                                    :source (process-public-address ,node)
+                                    :source ,node
                                     :message-id (message-message-id ,message)
                                     :payload-type ',message-type))
                        (return-from %message-dispatch
@@ -206,10 +204,9 @@ WARNING: These actions are to be thought of as \"interrupts\". Accordingly, you 
                     :peruse-inbox? (process-peruse-inbox? node))
     (message-RTS
      (when (process-debug? node)
-       (log-entry :source-type (type-of node)
-                  :time (now)
+       (log-entry :time (now)
                   :entry-type 'handler-invoked
-                  :source (process-public-address node)
+                  :source node
                   :message-id (message-message-id message)
                   :payload-type (type-of message)))
      (return-from message-dispatch
@@ -323,8 +320,7 @@ Locally enables the use of the function PROCESS-DIE and the special form SYNC-RE
                       (when (process-debug? ,process-name)
                         (apply #'log-entry
                                (append initargs
-                                       (list :source (process-public-address ,process-name)
-                                             :source-type ',process-type
+                                       (list :source ,process-name
                                              :time (now)))))))
                (initialize-and-return ((,active? t))
                  (handler-case

--- a/tests/event.lisp
+++ b/tests/event.lisp
@@ -18,7 +18,6 @@
 (define-object-handler ((a a))
   (incf (a-slot a) 2)
   (log-entry :source a
-             :source-type (type-of a)
              :time (now)
              :entry-type 'a
              :slot (a-slot a))
@@ -26,7 +25,6 @@
 
 (define-object-handler ((b b))
   (log-entry :source b
-             :source-type (type-of b)
              :time (now)
              :entry-type 'b)
   (when (< (now) (b-cutoff b))
@@ -35,7 +33,6 @@
 
 (define-object-handler ((c c))
   (log-entry :source c
-             :source-type (type-of c)
              :time (now)
              :entry-type 'c)
   (call-next-method))


### PR DESCRIPTION
...in favor of using `:source`