### PR TITLE
hide `check-address-key` behind `policy-cond`; `q-deq-first` speedup

### DIFF
--- a/src/courier.lisp
+++ b/src/courier.lisp
@@ -209,7 +209,9 @@ NOTES:
       `(block ,block-name
          (policy-cond:policy-cond
           ((= 3 safety)
-           (check-key-secret ,address)))
+            (check-key-secret ,address))
+          ((> 3 safety)
+            nil))
          (let ((,q-deq-fn (if ,peruse-inbox? #'q-deq-first #'q-deq-when)))
            (multiple-value-bind (,inbox ,found?)
                (gethash (address-channel ,address)

--- a/src/courier.lisp
+++ b/src/courier.lisp
@@ -207,7 +207,9 @@ NOTES:
                   (values (progn ,@clause-body)
                           t)))))
       `(block ,block-name
-         (check-key-secret ,address)
+         (policy-cond
+          ((= 3 safety)
+           (check-key-secret ,address)))
          (let ((,q-deq-fn (if ,peruse-inbox? #'q-deq-first #'q-deq-when)))
            (multiple-value-bind (,inbox ,found?)
                (gethash (address-channel ,address)

--- a/src/courier.lisp
+++ b/src/courier.lisp
@@ -207,7 +207,7 @@ NOTES:
                   (values (progn ,@clause-body)
                           t)))))
       `(block ,block-name
-         (policy-cond
+         (policy-cond:policy-cond
           ((= 3 safety)
            (check-key-secret ,address)))
          (let ((,q-deq-fn (if ,peruse-inbox? #'q-deq-first #'q-deq-when)))

--- a/src/queue.lisp
+++ b/src/queue.lisp
@@ -34,9 +34,11 @@
 
 (defun q-deq-first (q pred)
   "Dequeue the first message in `Q' that satisfies `PRED'."
+  (declare (optimize (speed 3) (safety 0)))
+  (declare (pred ftype))
   (labels ((aux (q pred)
              (cond
-               ((eql (cdar q) (cdr q))
+               ((eq (cdar q) (cdr q))
                 nil)
                ((funcall pred (cadar q))
                 (let ((item (cadar q)))

--- a/src/queue.lisp
+++ b/src/queue.lisp
@@ -35,7 +35,7 @@
 (defun q-deq-first (q pred)
   "Dequeue the first message in `Q' that satisfies `PRED'."
   (declare (optimize (speed 3) (safety 0)))
-  (declare (pred ftype))
+  (check-type pred function)
   (labels ((aux (q pred)
              (cond
                ((eq (cdar q) (cdr q))


### PR DESCRIPTION
+ tried custom fixnum-= courier hashes, no real change
+ hide check-address-key behind policy-cond
+ q-deq-first declare optimize

another 20% down on the test bench