### PR TITLE
perf: cheaper heap

### DIFF
--- a/src/cheap-heap.lisp
+++ b/src/cheap-heap.lisp
@@ -10,54 +10,66 @@
 
 (in-package #:aether)
 
-(defun make-cheap-heap ()
-  (list (cons -1 nil) nil))
+(defstruct (cheap-heap)
+  (queues (list (cons -1 nil) nil))
+  (hash (make-hash-table)))
 
 (defun cheap-heap-enqueue (heap item key)
-  ;; fast-forward 'til we're at the end of the buckets "behind" this key
-  (when (and (cadr heap)
-             (> key (caadr heap)))
-    (return-from cheap-heap-enqueue
-      (cheap-heap-enqueue (cdr heap) item key)))
-  ;; get a queue for this key
-  (let (queue)
-    ;; at this point HEAP looks like (_ (key' . queue) ...) or (_ nil).
-    ;; if key' exists and is equal to key, we use queue.
-    ;; otherwise, we inject a new (key . queue) pair here.
-    (cond
-      ((and (cadr heap)
-            (= (caadr heap) key))
-       (setf queue (cdadr heap)))
-      (t
-       (setf queue (make-q)
-             (cdr heap) (list* (cons key queue) (cdr heap)))))
-    ;; finally, enqueue the actual item into this queue
-    (q-enq item queue)
-    (values)))
+  ;; if we can find a write pointer, use it
+  (with-slots (hash queues) heap
+    (multiple-value-bind (queue found?) (gethash key hash)
+      (unless found?
+        ;; otherwise, need to build a fresh one
+        (labels ((add-queue (queues key)
+                   ;; we're not past the smaller buckets, fast forward
+                   (when (and (cadr queues)
+                              (> key (caadr queues)))
+                     (return-from add-queue (add-queue (cdr queues) key)))
+                   ;; we are past the smaller buckets.  the nonexistence of the
+                   ;; write pointer guarantees that the key at our cursor is
+                   ;; larger than the one we're searching for (or empty), so
+                   ;; we add a fresh bucket here.
+                   (setf queue (make-q)
+                         (gethash key hash) queue
+                         (cdr queues) (list* (cons key queue) (cdr queues)))))
+          (add-queue queues key)))
+      (q-enq item queue)
+      (values))))
 
 (defun cheap-heap-dequeue (heap)
-  (unless (cadr heap)
-    (return-from cheap-heap-dequeue nil))
-  (when (q-peek (cdadr heap))
-    (return-from cheap-heap-dequeue
-      (q-deq (cdadr heap))))
-  (setf (cdr heap) (cddr heap))
-  (cheap-heap-dequeue heap))
+  (with-slots (queues hash) heap
+    ;; no more queues in heap
+    (unless (cadr queues)
+      (return-from cheap-heap-dequeue nil))
+    ;; top queue in heap is nonempty
+    (multiple-value-bind (value nonempty?) (q-deq (cdadr queues))
+      (when nonempty?
+        (return-from cheap-heap-dequeue value)))
+    ;; top queue in heap is empty
+    (remhash (cdar queues) hash)
+    (setf (cdr queues) (cddr queues))
+    (cheap-heap-dequeue heap)))
 
 ;; REM: cheap-heap-deep-peep also ripe for implementation
 (defun cheap-heap-peep (heap)
-  (cond
-    ((and (cadr heap)
-          (q-peek (cdadr heap)))
-     (q-peek (cdadr heap)))
-    ((and (caddr heap)
-          (q-peek (cdaddr heap)))
-     (q-peek (cdaddr heap)))
-    (t
-     nil)))
+  (with-slots (queues) heap
+    (cond
+      ;; there is a top queue
+      ((and (cadr queues)
+            (q-peek (cdadr queues)))
+       (values (q-peek (cdadr queues)) t))
+      ;; there is a second queue
+      ;; TODO: i think this is wrong is general?? only fine for simulations which don't rewind.
+      ((and (caddr queues)
+            (q-peek (cdaddr queues)))
+       (values (q-peek (cdaddr queues)) t))
+      ;; there isn't a top queue
+      (t
+       (values nil nil)))))
 
 (defun cheap-heap-empty? (heap)
-  (equalp heap (make-cheap-heap)))
+  (loop :for (_key . q) :in (rest (cheap-heap-queues heap))
+        :always (or (null q) (q-empty q))))
 
 (defun cheap-heap->list (heap)
   (labels ((aux (heap &optional (list nil))

--- a/src/cheap-heap.lisp
+++ b/src/cheap-heap.lisp
@@ -46,7 +46,7 @@
       (when nonempty?
         (return-from cheap-heap-dequeue value)))
     ;; top queue in heap is empty
-    (remhash (cdar queues) hash)
+    (remhash (caadr queues) hash)
     (setf (cdr queues) (cddr queues))
     (cheap-heap-dequeue heap)))
 

--- a/src/courier.lisp
+++ b/src/courier.lisp
@@ -255,10 +255,10 @@ NOTES:
 (defgeneric wake-up (courier)
   (:documentation "If this actor has previously fallen asleep and was removed from the simulation heap, this re-inserts it.  (No action if the actor is already awake.)")
   (:method ((courier courier))
-    (a:when-let* ((since (courier-asleep-since courier))
-                  (next-tick (+ since
-                                (/ (ceiling (- (now) since)
-                                            (/ (courier-processing-clock-rate courier)))
-                                   (courier-processing-clock-rate courier)))))
-      (setf (courier-asleep-since courier) nil)
-      (schedule courier next-tick))))
+    (a:when-let ((since (courier-asleep-since courier)))
+      (let ((next-tick (+ since
+                          (/ (ceiling (- (now) since)
+                                      (/ (courier-processing-clock-rate courier)))
+                             (courier-processing-clock-rate courier)))))
+        (setf (courier-asleep-since courier) nil)
+        (schedule courier next-tick)))))

--- a/src/event.lisp
+++ b/src/event.lisp
@@ -39,7 +39,7 @@
 CONTENTS: The set of EVENTs.  This field is not for direct access; instead, add events using SIMULATION-ADD-EVENT.
 
 HORIZON: The timestamp before which all events have been simulated.  Ensures that a SIMULATION has a fixed history."
-  (contents nil :type list)
+  (contents (make-cheap-heap) :type cheap-heap)
   (horizon  0   :type (real 0)))
 
 (defun make-simulation ()

--- a/src/process/process.lisp
+++ b/src/process/process.lisp
@@ -363,11 +363,11 @@ Locally enables the use of the function PROCESS-DIE and the special form SYNC-RE
            (schedule process (+ (now) (/ process-clock-rate)))))))))
 
 (defmethod wake-up ((process process))
-  (a:when-let* ((since (process-asleep-since process))
-                (next-tick (+ since
-                              (/ (1+ (floor (- (now) since)
-                                            (/ (process-clock-rate process))))
-                                 (process-clock-rate process)))))
-    (assert (<= (now) next-tick))
-    (setf (process-asleep-since process) nil)
-    (schedule process next-tick)))
+  (a:when-let ((since (process-asleep-since process)))
+    (let ((next-tick (+ since
+                        (/ (1+ (floor (- (now) since)
+                                      (/ (process-clock-rate process))))
+                           (process-clock-rate process)))))
+      (assert (<= (now) next-tick))
+      (setf (process-asleep-since process) nil)
+      (schedule process next-tick))))

--- a/src/queue.lisp
+++ b/src/queue.lisp
@@ -23,8 +23,9 @@
   q)
 
 (defun q-deq (q)
-  (values (if (q-empty q) nil (pop (cdar q)))
-          q))
+  (let ((nonempty? (not (q-empty q))))
+    (values (and nonempty? (pop (cdar q)))
+            nonempty?)))
 
 (defun q-peek (q)
   (if (q-empty q) nil (cadar q)))


### PR DESCRIPTION
1. early abort on calculating wake-up time
2. add write pointers to cheap heap for faster second-time writes
3. TODO: replace linked list of buckets in cheap heap with priority queue?

currently taking profiles to see the effect of 1. + 2.