### PR TITLE
Allow for specifying a `log-level` when initializing a logger

### DIFF
--- a/src/debug/logger.lisp
+++ b/src/debug/logger.lisp
@@ -10,7 +10,7 @@
 (setf (documentation *logger* 'variable)
       "Logging object that captures entries.")
 
-(defparameter *log-level* nil)
+(defparameter *log-level* 0)
 (setf (documentation *log-level* 'variable)
       "A non-negative INTEGER that describes what level of logging to perform. Entries by default are given a log-level of 0, akin to DEBUG logging. Larger integers are used for logging more critical events.")
 
@@ -29,7 +29,7 @@
                   &allow-other-keys)
   "Injects a log entry."
   (declare (ignore source entry-type time))
-  (when (and logger *log-level* (>= log-level *log-level*))
+  (when (and logger (>= log-level *log-level*))
     (let ((keys (copy-seq initargs)))
       (remf keys ':logger)
       (push keys (logger-entries logger))

--- a/src/debug/logger.lisp
+++ b/src/debug/logger.lisp
@@ -146,16 +146,16 @@
 
 (defun print-log (&key (entries (logger-entries *logger*))
                        (stream *standard-output*)
-                       (start-time nil start-time-p)
-                       (end-time nil end-time-p)
-                       (log-level nil log-level-p))
+                       (start-time nil)
+                       (end-time nil)
+                       (log-level nil))
   "Iterate through the entries in `LOGGER' in reverse order and print them to `STREAM' using `PRINT-LOG-ENTRY', which can be specialized on `SOURCE' and `ENTRY-TYPE'. For convenience, the `START-TIME', `END-TIME', and `LOG-LEVEL' keywords can be used to trim the log entries before printing."
   (let ((entries-to-print (copy-list entries)))
-    (when start-time-p
+    (when start-time
       (setf entries-to-print (trim-log :entries entries-to-print :start-time start-time)))
-    (when end-time-p
+    (when end-time
       (setf entries-to-print (trim-log :entries entries-to-print :end-time end-time)))
-    (when log-level-p
+    (when log-level
       (setf entries-to-print (logs-from-level log-level entries-to-print)))
     (dolist (entry (reverse entries-to-print))
       (print-log-entry entry

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -46,6 +46,7 @@
   ;; logger.lisp
   (:export
    #:*logger*                           ; PARAMETER
+   #:*log-level*                        ; PARAMETER
    #:logger-entries                     ; ACCESSOR
    #:log-entry                          ; FUNCTION
    #:reset-logger                       ; FUNCTION
@@ -59,6 +60,7 @@
    #:logs-for-process                   ; FUNCTION
    #:logs-for-address                   ; FUNCTION
    #:logs-for-channel                   ; FUNCTION
+   #:logs-from-level                    ; FUNCTION
    )
   
   ;; event.lisp


### PR DESCRIPTION
Kept track of via a new parameter:

```lisp
(defparameter *log-level* nil)
(setf (documentation *log-level* 'variable)
      "A non-negative INTEGER that describes what level of logging to perform.
       Entries by default are given a log-level of 0, akin to DEBUG logging.
       Larger integers are used for logging more critical events.")
```

Set by providing a `:log-level` argument to the `with-transient-logger` macro:

```lisp
(with-transient-logger (:log-level 1) ...)
```

Also adds some frills to `print-log`.