### PR TITLE
fix `message-RTS` clause of `sync-rpc`

### DIFF
--- a/src/process/rpc.lisp
+++ b/src/process/rpc.lisp
@@ -41,7 +41,20 @@ If `RETURNED?' is supplied and this call generates a `MESSAGE-RTS' reply, then `
          (sync-receive (,listen-channel ,message-place)
            ,@(unless (null returned?)
                `((message-RTS
-                  (setf ,returned? t))))
+                  ,(etypecase result-place-or-list
+                     (symbol
+                      `(let ((,result-place-or-list nil))
+                         ,@decls
+                         (declare (ignorable ,result-place-or-list))
+                         (unregister ,listen-channel)
+                         (setf ,returned? t)
+                         ,@body))
+                     (list
+                      `(destructuring-bind ,result-place-or-list (list ,@(mapcar (constantly nil) result-place-or-list))
+                         ,@decls
+                         (unregister ,listen-channel)
+                         (setf ,returned? t)
+                         ,@body))))))
            (,message-type
             ,(etypecase result-place-or-list
                (symbol

--- a/src/process/rpc.lisp
+++ b/src/process/rpc.lisp
@@ -32,39 +32,41 @@ Sends `MESSAGE' to `DESTINATION', waits for a reply (of type `MESSAGE-TYPE'), an
 If `RETURNED?' is supplied and this call generates a `MESSAGE-RTS' reply, then `RETURNED?' will be flagged and control resumes.  Otherwise, controlled is interrupted by an error."
   (multiple-value-bind (body decls) (a:parse-body body)
     (a:with-gensyms (listen-channel message-place our-message)
-      `(let* ((,listen-channel (register))
-              (,our-message (copy-structure ,message))
-              ,@(unless (null returned?) `(,returned?)))
-         ,@(unless (null returned?) `((declare (ignorable ,returned?))))
-         (setf (message-reply-channel ,our-message) ,listen-channel)
-         (send-message ,destination ,our-message)
-         (sync-receive (,listen-channel ,message-place)
-           ,@(unless (null returned?)
-               `((message-RTS
-                  ,(etypecase result-place-or-list
-                     (symbol
-                      `(let ((,result-place-or-list nil))
-                         ,@decls
-                         (declare (ignorable ,result-place-or-list))
-                         (unregister ,listen-channel)
-                         (setf ,returned? t)
-                         ,@body))
-                     (list
-                      `(destructuring-bind ,result-place-or-list (list ,@(mapcar (constantly nil) result-place-or-list))
-                         ,@decls
-                         (unregister ,listen-channel)
-                         (setf ,returned? t)
-                         ,@body))))))
-           (,message-type
-            ,(etypecase result-place-or-list
+      (labels
+          ((ignorables ()
+             (etypecase result-place-or-list
                (symbol
-                `(let ((,result-place-or-list (,message-unpacker ,message-place)))
-                   ,@decls
-                   (declare (ignorable ,result-place-or-list))
-                   (unregister ,listen-channel)
-                   ,@body))
+                `((declare (ignorable ,result-place-or-list))))
                (list
-                `(destructuring-bind ,result-place-or-list (,message-unpacker ,message-place)
-                   ,@decls
-                   (unregister ,listen-channel)
-                   ,@body)))))))))
+                `((declare (ignorable ,@result-place-or-list))))))
+           (body (rts)
+             `(,@decls
+               ,@(ignorables)
+               (unregister ,listen-channel)
+               ,@(when returned? `((setf ,returned? ,rts)))
+               ,@body)))
+        `(let* ((,listen-channel (register))
+                (,our-message (copy-structure ,message))
+                ,@(unless (null returned?) `(,returned?)))
+           ,@(unless (null returned?) `((declare (ignorable ,returned?))))
+           (setf (message-reply-channel ,our-message) ,listen-channel)
+           (send-message ,destination ,our-message)
+           (sync-receive (,listen-channel ,message-place)
+             ,@(unless (null returned?)
+                 `((message-RTS
+                    ,(etypecase result-place-or-list
+                       (symbol
+                        `(lax-destructuring-bind
+                             ,result-place-or-list
+                             nil
+                           ,@(body t)))
+                       (list
+                        `(lax-destructuring-bind
+                             ,result-place-or-list
+                             (list ,@(mapcar (constantly nil) result-place-or-list))
+                           ,@(body t)))))))
+             (,message-type
+              (lax-destructuring-bind
+                  ,result-place-or-list
+                  (,message-unpacker ,message-place)
+                ,@(body nil)))))))))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -166,3 +166,13 @@ WARNING: This routine is based on MAPHASH, which has undefined behavior if the s
        (ccl::atomic-incf ,counter-name)
        #-(or ccl ecl sbcl lispworks)
        (incf ,counter-name))))
+
+(defmacro lax-destructuring-bind (lambda-list value &body body)
+  "Same as DESTRUCTURING-BIND, but permits non-destructuring binds too."
+  (etypecase lambda-list
+    (symbol
+     `(let ((,lambda-list ,value))
+        ,@body))
+    (list
+     `(destructuring-bind ,lambda-list ,value
+        ,@body))))


### PR DESCRIPTION
On main, sync-rpc encountering a message-RTS causes it to set the returned? flag high and then exit the command, never passing control to the caller body to do anything with the flag. This bug has presumably been here since before we realized we needed to wrap the bodies of sync commands for use as a callback — so, 5 years or so.

I'm not sure this is the nicest possible fix. Certainly it doesn't work with all possible unpack lambda lists.